### PR TITLE
Add CI via GitHub Actions and Coveralls coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: ride_my_way_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Write .env.test
+        run: |
+          echo "DATABASE_URL=postgres://postgres:postgres@localhost:5432/ride_my_way_test" >> .env.test
+          echo "JWT_SECRET=ci-only-secret-not-used-in-production" >> .env.test
+
+      - run: npm run lint
+
+      - run: npm run test:coverage
+
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          path-to-lcov: coverage/lcov.info

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .idea/
 .env
 .env.test
+coverage/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Ride-My-Way
 
+[![CI](https://github.com/eben-k/Ride-My-Way/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/eben-k/Ride-My-Way/actions/workflows/ci.yml)
+[![Coverage Status](https://coveralls.io/repos/github/eben-k/Ride-My-Way/badge.svg?branch=develop)](https://coveralls.io/github/eben-k/Ride-My-Way?branch=develop)
+
 A carpooling application that provides drivers with the ability to create ride offers and passengers to join available ride offers.
 
 ## Status
@@ -76,6 +79,12 @@ The DOM-facing page scripts (`public/js/pages/*.js`) aren't unit tested — they
 ```
 npm run lint
 ```
+
+## Continuous integration
+
+`.github/workflows/ci.yml` runs on every push/PR against `develop`: spins up a Postgres service container, runs `npm run lint` and `npm run test:coverage` (Node's built-in coverage, via `--experimental-test-coverage`, written out as `coverage/lcov.info`), then uploads that to Coveralls.
+
+This is the modern replacement for what the original project spec asked for with TravisCI — Travis's free tier for open source no longer exists, so GitHub Actions covers that role instead. Coveralls itself is unchanged and still free for public repos.
 
 ## GitHub Pages
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node --env-file=.env server/index.js",
     "migrate": "node --env-file=.env server/db/migrate.js",
     "test": "node --env-file=.env.test server/db/migrate.js && node --env-file=.env.test --test --test-concurrency=1 'server/test/**/*.test.js' 'public/js/test/**/*.test.js'",
-    "test:coverage": "node --env-file=.env.test server/db/migrate.js && node --env-file=.env.test --experimental-test-coverage --test-coverage-include='server/**/*.js' --test-coverage-include='public/js/**/*.js' --test-coverage-exclude='**/test/**' --test --test-concurrency=1 --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info 'server/test/**/*.test.js' 'public/js/test/**/*.test.js'",
+    "test:coverage": "node --env-file=.env.test server/db/migrate.js && mkdir -p coverage && node --env-file=.env.test --experimental-test-coverage --test-coverage-include='server/**/*.js' --test-coverage-include='public/js/**/*.js' --test-coverage-exclude='**/test/**' --test --test-concurrency=1 --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info 'server/test/**/*.test.js' 'public/js/test/**/*.test.js'",
     "lint": "eslint ."
   },
   "author": "Eben",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "node --env-file=.env server/index.js",
     "migrate": "node --env-file=.env server/db/migrate.js",
     "test": "node --env-file=.env.test server/db/migrate.js && node --env-file=.env.test --test --test-concurrency=1 'server/test/**/*.test.js' 'public/js/test/**/*.test.js'",
+    "test:coverage": "node --env-file=.env.test server/db/migrate.js && node --env-file=.env.test --experimental-test-coverage --test-coverage-include='server/**/*.js' --test-coverage-include='public/js/**/*.js' --test-coverage-exclude='**/test/**' --test --test-concurrency=1 --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info 'server/test/**/*.test.js' 'public/js/test/**/*.test.js'",
     "lint": "eslint ."
   },
   "author": "Eben",


### PR DESCRIPTION
Replaces the original spec's TravisCI ask, which no longer has a free tier for open source. GitHub Actions runs lint + the full test suite against a real Postgres service container on every push/PR to develop. Coverage comes from Node's built-in test runner
(--experimental-test-coverage + the lcov reporter) rather than adding nyc/istanbul, and uploads to Coveralls, which is still free for public repos.