### PR TITLE
Style rides list links to match the site palette

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -202,6 +202,16 @@ ul.ride-list li {
   background: #ffffff;
 }
 
+ul#rides li a {
+  color: #2f6d4f;
+  font-weight: bold;
+  text-decoration: none;
+}
+
+ul#rides li a:hover {
+  text-decoration: underline;
+}
+
 .btn-group {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
The "View details & request to join" link was rendering as the browser default blue/underlined link instead of the green used everywhere else on the site.